### PR TITLE
Add meta dump

### DIFF
--- a/CultureObject/Display/COD.class.php
+++ b/CultureObject/Display/COD.class.php
@@ -59,13 +59,32 @@ class COD  {
         
         $all_meta = get_post_meta(get_the_ID());
         
-        
         if (isset($_GET['displayallmeta'])) {
-            
-            $html .= '<h2>All object metadata</h2>';
+            // Add the styles for the <pre> element
+            $html .= '<style>               
+                .allmeta { padding:20px; background-color:#f9f9f9;border:1px dotted #000000}
+                pre {
+                    background-color: #f4f4f4; 
+                    border: 1px solid #ddd;   
+                    padding: 10px;             
+                    font-family: "Courier New", Courier, monospace;
+                    font-size: 14px;           
+                    color: #333;               
+                    overflow-x: auto;          
+                    white-space: pre-wrap;     
+                    word-wrap: break-word;     
+                    border-radius: 5px;
+                }
+                
+            </style>';
+        
+            // Add heading and metadata dump to the HTML
+            $html .= '<div class="allmeta">';
+            $html .= '<h3>All object metadata</h3>';
             $html .= '<pre>';
             $html .= print_r($all_meta, true);  
             $html .= '</pre>';
+            $html .= '</div>';
         }
         
         return $html;

--- a/CultureObject/Display/COD.class.php
+++ b/CultureObject/Display/COD.class.php
@@ -56,6 +56,18 @@ class COD  {
         $html = apply_filters('the_content', $html);
         add_filter('the_content', array($this, 'provide_content'), 1);
         
+        
+        $all_meta = get_post_meta(get_the_ID());
+        
+        
+        if (isset($_GET['displayallmeta'])) {
+            
+            $html .= '<h2>All object metadata</h2>';
+            $html .= '<pre>';
+            $html .= print_r($all_meta, true);  
+            $html .= '</pre>';
+        }
+        
         return $html;
         
     }


### PR DESCRIPTION
Ok so @lgladdy - MDS want a way of seeing all data on an object record.

I think this is simple enough that it doesn't get in the way of other providers...

I'm basically just dumping post meta if the url has ?displayallmeta

